### PR TITLE
Fix TimeLog-Grouping Bug

### DIFF
--- a/src/app/components/recent-time-logs/recent-time-logs.component.ts
+++ b/src/app/components/recent-time-logs/recent-time-logs.component.ts
@@ -75,9 +75,9 @@ export class RecentTimeLogsComponent implements OnInit, OnChanges {
 
   compareDatesEqual(d1: Date, d2: Date) {
     if (
-      d1.getDay() == d2.getDay() &&
-      d1.getMonth() == d2.getMonth() &&
-      d1.getFullYear() == d2.getFullYear()
+      d1.getUTCDay() === d2.getUTCDay() &&
+      d1.getUTCMonth() === d2.getUTCMonth() &&
+      d1.getUTCFullYear() === d2.getUTCFullYear()
     ) {
       return true;
     }


### PR DESCRIPTION
Should resolve #70 . If not, we should consider taking a look at DataService. We suspect, the Time-Formats of the different browser/devices might cause the bug, as the same list of Logs is sorted differently on different devices.